### PR TITLE
Evict oldest DataFrames from session state to bound memory growth

### DIFF
--- a/src/claude_handler.py
+++ b/src/claude_handler.py
@@ -67,6 +67,8 @@ def df_summary(df: pd.DataFrame) -> str:
     return "\n".join(lines)
 
 
+MAX_STORED_DATAFRAMES = 10
+
 # ---------------------------------------------------------------------------
 # ClaudeHandler
 # ---------------------------------------------------------------------------
@@ -277,13 +279,34 @@ class ClaudeHandler:
             return "Query returned no rows."
         st.session_state.dataframes[dataframe_id] = df
         st.session_state.artifact_order.append(("dataframe", dataframe_id))
+        self._evict_dataframes()
         return df_summary(df)
 
     def _show_table(self, dataframe_id: str) -> str:
         if dataframe_id not in st.session_state.dataframes:
             return f"Error: '{dataframe_id}' not found. Call run_sql first."
+        st.session_state.shown_dataframes.add(dataframe_id)
         st.session_state.tables_to_show.append(dataframe_id)
         return "Displayed to user."
+
+    def _evict_dataframes(self) -> None:
+        """Evict oldest DataFrames once the store exceeds MAX_STORED_DATAFRAMES.
+
+        DataFrames marked as shown via show_table are protected — evicting them
+        would break table display when the user scrolls up. Only intermediate
+        DataFrames (used as chart/python inputs but never directly shown) are
+        candidates for eviction.
+        """
+        if len(st.session_state.dataframes) <= MAX_STORED_DATAFRAMES:
+            return
+        protected = st.session_state.get("shown_dataframes", set())
+        ordered_ids = list(dict.fromkeys(
+            aid for kind, aid in st.session_state.artifact_order if kind == "dataframe"
+        ))
+        evict_candidates = [i for i in ordered_ids if i not in protected]
+        n_to_evict = len(st.session_state.dataframes) - MAX_STORED_DATAFRAMES
+        for eid in evict_candidates[:n_to_evict]:
+            st.session_state.dataframes.pop(eid, None)
 
     def _render_chart(self, dataframe_id: str, code: str, chart_id: str | None) -> str:
         df = st.session_state.dataframes.get(dataframe_id)

--- a/src/pages/conversation.py
+++ b/src/pages/conversation.py
@@ -86,7 +86,7 @@ def _replay_tool_calls(messages: list[dict], handler) -> None:
         if msg["role"] != "assistant":
             continue
         for block in msg["content"]:
-            if block.get("type") == "tool_use" and block["name"] in ("run_sql", "run_python", "render_chart", "save_file"):
+            if block.get("type") == "tool_use" and block["name"] in ("run_sql", "run_python", "render_chart", "save_file", "show_table"):
                 handler._execute_tool(block["name"], block["input"])
 
 
@@ -143,6 +143,7 @@ def _init_session():
         st.session_state.figures = {}
         st.session_state.artifact_order = []
         st.session_state.tables_to_show = []
+        st.session_state.shown_dataframes = set()
         st.session_state.exported_files = {}
         saved = conv_file.load_messages(path) if path else []
         st.session_state.messages = saved


### PR DESCRIPTION
Adds MAX_STORED_DATAFRAMES=10 cap with LRU-style eviction on each run_sql call. DataFrames shown via show_table are protected so scrolled-up tables remain visible. Charts are unaffected (rendered figures live in session_state.figures). Initialises shown_dataframes in _init_session and replays show_table calls on conversation load to restore protection state correctly.